### PR TITLE
Uses standard WPILib method for getting version numbers

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,12 +4,8 @@ import com.github.spotbugs.SpotBugsExtension
 import edu.wpi.first.wpilib.versioning.ReleaseType
 import org.gradle.api.Project
 import org.gradle.api.publish.maven.MavenPublication
-import org.gradle.api.tasks.wrapper.Wrapper
 import org.gradle.jvm.tasks.Jar
 import org.gradle.testing.jacoco.tasks.JacocoReport
-import org.ajoberstar.grgit.Grgit
-import org.ajoberstar.grgit.exception.GrgitException
-import org.ajoberstar.grgit.operation.DescribeOp
 import java.time.Instant
 
 buildscript {
@@ -17,27 +13,42 @@ buildscript {
         mavenCentral()
         jcenter()
     }
-    dependencies {
-        classpath("org.ajoberstar:grgit:1.7.2")
-    }
 }
 plugins {
     `maven-publish`
     jacoco
-    id("edu.wpi.first.wpilib.versioning.WPILibVersioningPlugin") version "2.0"
+    id("edu.wpi.first.wpilib.versioning.WPILibVersioningPlugin") version "2.2"
     id("com.github.johnrengelman.shadow") version "2.0.1"
     id("com.diffplug.gradle.spotless") version "3.13.0"
-    id("org.ajoberstar.grgit") version "1.7.2"
     id("com.github.spotbugs") version "1.6.4"
     id("com.google.osdetector") version "1.4.0"
 }
+
+// Ensure that the WPILibVersioningPlugin is setup by setting the release type, if releaseType wasn't
+// already specified on the command line
+if (!hasProperty("releaseType")) {
+    WPILibVersion {
+        releaseType = ReleaseType.DEV
+    }
+}
+
+// Only load the project version once, then share it
+val projectVerion = getWPILibVersion()
 
 allprojects {
     apply {
         plugin("com.diffplug.gradle.spotless")
     }
 
-    getWPILibVersion()?.let { version = it }
+    version = projectVerion
+
+    // Note: plugins should override this
+    tasks.withType<Jar>().configureEach {
+        manifest {
+            attributes["Implementation-Version"] = project.version as String
+            attributes["Built-Date"] = Instant.now().toString()
+        }
+    }
 
     // Spotless is used to lint and reformat source files.
     spotless {
@@ -109,7 +120,6 @@ allprojects {
         plugin("com.github.spotbugs")
         plugin("jacoco")
         plugin("maven-publish")
-        plugin("edu.wpi.first.wpilib.versioning.WPILibVersioningPlugin")
     }
     repositories {
         mavenCentral()
@@ -206,17 +216,6 @@ allprojects {
     tasks.withType<Javadoc> {
         isFailOnError = false
     }
-
-    afterEvaluate {
-        // Note: plugins should override this
-        version = getWPILibVersion() ?: getVersionFromGitTag()
-        tasks.withType<Jar> {
-            manifest {
-                attributes["Implementation-Version"] = project.version as String
-                attributes["Built-Date"] = Instant.now().toString()
-            }
-        }
-    }
 }
 
 project(":api") {
@@ -236,7 +235,7 @@ project(":api") {
             create<MavenPublication>("api") {
                 groupId = "edu.wpi.first.shuffleboard"
                 artifactId = "api"
-                getWPILibVersion()?.let { version = it }
+                version = project.version.toString()
                 afterEvaluate {
                     from(components["java"])
                 }
@@ -247,21 +246,23 @@ project(":api") {
     }
 }
 
-// Ensure that the WPILibVersioningPlugin is setup by setting the release type, if releaseType wasn't
-// already specified on the command line
-if (!hasProperty("releaseType")) {
-    WPILibVersion {
-        releaseType = ReleaseType.DEV
+/**
+ * @return publishVersion property if exists, otherwise
+ * [edu.wpi.first.wpilib.versioning.WPILibVersioningPluginExtension.version] value or fallback
+ * if that value is the empty string.
+ */
+fun getWPILibVersion(fallback: String = "v0.0.0"): String {
+    if (project.hasProperty("publishVersion")) {
+        val publishVersion: String by project
+        return publishVersion
+    } else if (WPILibVersion.version != "") {
+        return WPILibVersion.version
+    } else {
+        return fallback
     }
 }
 
-/**
- * @return [edu.wpi.first.wpilib.versioning.WPILibVersioningPluginExtension.version] value or null
- * if that value is the empty string.
- */
-fun getWPILibVersion(): String? = if (WPILibVersion.version != "") WPILibVersion.version else null
-
-task<Wrapper>("wrapper") {
+tasks.withType<Wrapper>().configureEach {
     gradleVersion = "4.9"
 }
 
@@ -304,21 +305,3 @@ val Project.`spotbugs`: SpotBugsExtension
 
 fun Project.`spotbugs`(configure: SpotBugsExtension.() -> Unit) =
         extensions.configure("spotbugs", configure)
-
-/**
- * Gets the build version from git-describe. This is a combination of the most recent tag, the number of commits since
- * that tag, and the abbreviated hash of the most recent commit, in this format: `<tag>-<n>-<hash>`; for example,
- * v1.0.0-11-9ab123f when the most recent tag is `"v1.0.0"`, with 11 commits since that tag, and the most recent commit
- * hash starting with `9ab123f`.
- *
- * @param fallback the version string to fall back to if git-describe fails. Default value is `"v0.0.0"`.
- *
- * @see <a href="https://git-scm.com/docs/git-describe">git-describe documentation</a>
- */
-fun getVersionFromGitTag(fallback: String = "v0.0.0"): String = try {
-    val git = Grgit.open()
-    DescribeOp(git.repository).call() ?: fallback
-} catch (e: GrgitException) {
-    logger.log(LogLevel.WARN, "Cannot get the version from git-describe, falling back to $fallback")
-    fallback
-}

--- a/plugins/plugins.gradle.kts
+++ b/plugins/plugins.gradle.kts
@@ -1,15 +1,8 @@
-import edu.wpi.first.wpilib.versioning.ReleaseType
+
 import org.gradle.jvm.tasks.Jar
 
 subprojects {
     afterEvaluate {
-        // Ensure that the WPILibVersioningPlugin is setup by setting the release type, if releaseType wasn't
-        // already specified on the command line
-        if (!hasProperty("releaseType")) {
-            WPILibVersion {
-                releaseType = ReleaseType.DEV
-            }
-        }
         apply(plugin = "java-library")
         dependencies {
             compileOnly(group = "com.google.code.findbugs", name = "annotations", version = "+")
@@ -30,7 +23,7 @@ subprojects {
             create<MavenPublication>("plugin.${project.name}") {
                 groupId = "edu.wpi.first.shuffleboard.plugin"
                 artifactId = project.name
-                getWPILibVersion()?.let { version = it }
+                version = project.version as String
                 from(components["java"])
                 artifact(javadocJar)
                 artifact(sourceJar)
@@ -38,9 +31,3 @@ subprojects {
         }
     }
 }
-
-/**
- * @return [edu.wpi.first.wpilib.versioning.WPILibVersioningPluginExtension.version] value or null
- * if that value is the empty string.
- */
-fun getWPILibVersion(): String? = if (WPILibVersion.version != "") WPILibVersion.version else null


### PR DESCRIPTION
Only grabs it once, shares it with projects, and properly falls back.

Also allows using the publishVersion property from cmd to manually set version

Finally fixes a deprecation error with the wrapper task

<!--
If you have modified classes in a plugin (plugins/base, plugins/cameraserver, etc.),
make sure you have updated the version of the plugin in the @Description annotation on the plugin class
-->

# Overview
<!-- What does this pull request do? -->

# Screenshots
<!-- Add screenshots of the new or fixed features, if you modified widgets or the UI -->
